### PR TITLE
fix srcset import when attribute uses whitespace

### DIFF
--- a/lib/template-compiler/modules/transform-srcset.js
+++ b/lib/template-compiler/modules/transform-srcset.js
@@ -9,7 +9,9 @@ module.exports = function () {
 }
 
 function transform (node) {
-  if (node.tag === 'img' && node.attrs) {
+  const tags = ['img', 'source']
+  
+  if (tags.indexOf(node.tag) !== -1 && node.attrs) {
     node.attrs.forEach(attr => {
       if (attr.name === 'srcset') {
         // same logic as in transform-require.js
@@ -22,15 +24,16 @@ function transform (node) {
         // http://w3c.github.io/html/semantics-embedded-content.html#ref-for-image-candidate-string-5
 
         const spaceCharacters = /[ \t\n\f\r]+/
+        const escapedSpaceCharacters = /^([ \t\n\f\r]|\\t|\\n|\\f|\\r)*/
 
         const imageCandidates = value.substr(1, value.length - 2).split(',').map(s => {
-          const [url, descriptor] = s.trim().split(spaceCharacters, 2)
+          const [url, descriptor] = s.replace(escapedSpaceCharacters, '').split(spaceCharacters, 2)
           return { require: urlToRequire(url), descriptor: descriptor }
         })
 
         let code = ''
         imageCandidates.forEach((o, i, a) => {
-          code += o.require + ' + " ' + o.descriptor + (i < a.length - 1 ? ',' : '') + '"'
+          code += o.require + ' + " ' + o.descriptor + (i < a.length - 1 ? ', " + ' : '"')
         })
 
         attr.value = code
@@ -39,14 +42,15 @@ function transform (node) {
   }
 }
 
-function urlToRequire (url) {
-	// same logic as in transform-require.js
-  var firstChar = url.charAt(0)
-  if (firstChar === '.' || firstChar === '~') {
-    if (firstChar === '~') {
-      var secondChar = url.charAt(1)
-      url = '"' + url.slice(secondChar === '/' ? 2 : 1)
+  function urlToRequire (url) {
+  	// same logic as in transform-require.js
+    var firstChar = url.charAt(0)
+    if (firstChar === '.' || firstChar === '~') {
+      if (firstChar === '~') {
+        var secondChar = url.charAt(1)
+        url = '"' + url.slice(secondChar === '/' ? 2 : 1)
+      }
+      return `require("${url}")`
+
     }
-    return 'require("' + url + '")'
   }
-}


### PR DESCRIPTION
covers cases like:
```
<img srcset="
    ../image.jpg 1x, 
    ../image.2x.jpg 2x,
    ../image.1920x1280.jpg 1920w
" alt="srcset on multiple lines and with extra whitespace">
```